### PR TITLE
Update Next.js image config to use remotePatterns instead of domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: [
-      "firebasestorage.googleapis.com"
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "firebasestorage.googleapis.com",
+      },
     ],
   },
 };


### PR DESCRIPTION
Replace deprecated 'domains' configuration with 'remotePatterns' for Firebase Storage images to align with Next.js 13+ best practices