### PR TITLE
Add unoptimized prop to Image components in admin pages

### DIFF
--- a/src/app/admin/images/page.tsx
+++ b/src/app/admin/images/page.tsx
@@ -158,6 +158,7 @@ function AdminImagesPage() {
             {images.map((image) => (
               <div key={image.refPath} className="relative group border rounded-lg overflow-hidden shadow-sm">
                 <Image
+                  unoptimized
                   src={image.url}
                   alt={image.name}
                   width={200}

--- a/src/app/admin/post/page.tsx
+++ b/src/app/admin/post/page.tsx
@@ -556,6 +556,7 @@ function AdminPostPage() {
                       title={`「${img.name}」を選択`}
                     >
                       <Image
+                        unoptimized
                         src={img.url}
                         alt={img.name}
                         width={200}

--- a/src/components/ImageDetailOverlay.tsx
+++ b/src/components/ImageDetailOverlay.tsx
@@ -35,6 +35,7 @@ const ImageDetailOverlay: React.FC<ImageDetailOverlayProps> = ({
         <p className="mb-4 text-sm text-foreground break-all">{image.name}</p>
         <div className="mb-6 rounded-md overflow-hidden border border-border">
           <Image
+            unoptimized
             src={image.url}
             alt={image.name}
             width={400}


### PR DESCRIPTION
Disable Next.js image optimization for admin image displays to improve loading performance and compatibility with external image sources.