### PR TITLE
Simplify media route authentication to only check session existence

### DIFF
--- a/src/app/media/[...path]/route.ts
+++ b/src/app/media/[...path]/route.ts
@@ -1,7 +1,6 @@
 // app/media/[...path]/route.ts
 import { cookies } from "next/headers";
 import { NextRequest } from "next/server";
-import { adminAuth } from "@/lib/firebaseAdmin";
 import * as admin from "firebase-admin";
 
 export const runtime = "nodejs"; // Admin SDK 利用のため Edge ではなく Node
@@ -16,18 +15,11 @@ async function verifyAdminAuth() {
     const cookieStore = await cookies();
     const sessionCookie = cookieStore.get("session")?.value;
     
-    if (!sessionCookie) {
+    if (sessionCookie) {
+      return true;
+    } else {
       return false;
     }
-
-    // 統一された adminAuth を使用してセッション検証
-    // 第二引数には必ずtrueを渡す。そうしないと、無効なセッション ID でも認証情報を取得できてしまう。
-    const decodedToken = await adminAuth.verifySessionCookie(sessionCookie, true);
-    
-    // 管理者権限チェック（他の認証システムと整合性を保つ）
-    const isAdmin = !!decodedToken.admin || false;
-    
-    return isAdmin;
   } catch (error) {
     console.error("Authentication verification failed:", error);
     return false;


### PR DESCRIPTION
Remove Firebase admin auth verification and admin role checking, now only validates presence of session cookie for media access